### PR TITLE
[Feature] ch19882 User can select instanceType when launch one-click URL

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -15,8 +15,9 @@ const basedDomain = app.node.tryGetContext('basedDomain') || process.env.AWS_BAS
 const primehubPassword = app.node.tryGetContext('primehubPassword') || process.env.PH_PASSWORD || crypto.randomBytes(32).toString('hex');
 const keycloakPassword = app.node.tryGetContext('keycloakPassword') || process.env.KC_PASSWORD || crypto.randomBytes(32).toString('hex');
 const zone = app.node.tryGetContext('zone') || 'a';
-const cpuInstance = app.node.tryGetContext('cpuInstance') || 't3a';
-const gpuInstance = app.node.tryGetContext('gpuInstance') || 'g4dn';
+const cpuInstance = app.node.tryGetContext('cpuInstance') || 't3a.xlarge';
+const gpuInstance = app.node.tryGetContext('gpuInstance') || 'g4dn.xlarge';
+const systemInstance = app.node.tryGetContext('systemInstance') || 't3a.xlarge';
 const k8sInfraOnly = app.node.tryGetContext('k8sInfraOnly') || 'false';
 
 const eksClusterStack = new EKSCluster(app, `eks-${name}-cdk-stack`, {
@@ -30,6 +31,7 @@ const eksClusterStack = new EKSCluster(app, `eks-${name}-cdk-stack`, {
   availabilityZone: `${env.region}${zone}`,
   cpuInstance: cpuInstance,
   gpuInstance: gpuInstance,
+  systemInstance: systemInstance,
   k8sInfraOnly: k8sInfraOnly
 });
 

--- a/deploy
+++ b/deploy
@@ -8,8 +8,9 @@ K8S_INFRA_ONLY=false
 AWS_ACCOUNT=${AWS_ACCOUNT:-}
 AWS_REGION=${AWS_REGION:-$(aws configure get region || echo 'ap-northeast-1')}
 AWS_ZONE=${AWS_ZONE:-a}
-CPU_INSTANCE='t3a'
-GPU_INSTANCE='g4dn'
+CPU_INSTANCE='t3a.xlarge'
+GPU_INSTANCE='g4dn.xlarge'
+SYS_INSTANCE='t3a.xlarge'
 PH_PASSWORD=''
 KC_PASSWORD=''
 
@@ -37,8 +38,9 @@ Options:
   --dry-run                   : Dry run AWS CDK deploy
   --k8s-infra                 : Only setup AWS ESK without installing PrimeHub
   --domain   <base domain>    : Provide the base domain managed by AWS Route 53
-  --cpuInstanceType           : Set the EKS default CPU instance type ( Default: ${CPU_INSTANCE} )
-  --gpuInstanceType           : Set the EKS default GPU instance type ( Default: ${GPU_INSTANCE} )
+  --cpuInstanceType           : Set the EKS default CPU node group instance type ( Default: ${CPU_INSTANCE} )
+  --gpuInstanceType           : Set the EKS default GPU node group instance type ( Default: ${GPU_INSTANCE} )
+  --systemInstanceType        : Set the EKS default system node group instance type ( Default: ${SYS_INSTANCE} )
   --keycloak-password         : Set the password of Keycloak admin account
   --primehub-password         : Set the password of PrimeHub default account
   -h, --help                  : Show this message
@@ -86,6 +88,7 @@ cdk::context() {
       -c zone=$AWS_ZONE \
       -c cpuInstance=$CPU_INSTANCE \
       -c gpuInstance=$GPU_INSTANCE \
+      -c systemInstance=$SYS_INSTANCE \
       -c basedDomain=$AWS_BASED_DOMAIN \
       -c primehubMode=$PRIMEHUB_MODE \
       -c primehubPassword=$PH_PASSWORD \
@@ -143,6 +146,10 @@ args::parse() {
       --gpuInstanceType)
         shift
         GPU_INSTANCE=${1}
+      ;;
+      --systemInstanceType)
+        shift
+        SYS_INSTANCE=${1}
       ;;
       --dry-run)
         DRY_MODE=true

--- a/extras/ec2-user-script.sh
+++ b/extras/ec2-user-script.sh
@@ -30,19 +30,21 @@ yarn install
 echo "Prepare CDK"
 AWS_REGION='us-east-1'
 AWS_ZONE='a'
-CPU_INSTANCE_TYPE='t3'
-GPU_INSTANCE_TYPE='g4dn'
+SYS_INSTANCE='t3.xlarge'
+CPU_INSTANCE="${CPU_INSTANCE:-'t3.xlage'}"
+GPU_INSTANCE="${GPU_INSTANCE:-'g4dn.xlarge'}"
 PASSWORD="$(openssl rand -hex 16)"
 echo "Name: ${AWS_STACK_NAME}"
 echo "Mode: ${PRIMEHUB_MODE}"
 echo "Region: ${AWS_REGION}"
 echo "Zone: ${AWS_ZONE}"
-echo "CPU Instance Type: ${CPU_INSTANCE_TYPE}"
-echo "GPU Instance Type: ${GPU_INSTANCE_TYPE}"
+echo "System Instance Type: ${SYS_INSTANCE_TYPE}"
+echo "CPU Instance Type: ${CPU_INSTANCE}"
+echo "GPU Instance Type: ${GPU_INSTANCE}"
 
 echo "Deploy CDK ${AWS_STACK_NAME}"
 export AWS_REGION
-./deploy ${AWS_STACK_NAME} --region ${AWS_REGION} --zone ${AWS_ZONE} --cpuInstanceType ${CPU_INSTANCE_TYPE} --gpuInstanceType ${GPU_INSTANCE_TYPE} --mode ${PRIMEHUB_MODE} --keycloak-password ${PASSWORD} --primehub-password ${PASSWORD} || exit 1
+./deploy ${AWS_STACK_NAME} --region ${AWS_REGION} --zone ${AWS_ZONE} --systemInstanceType ${SYS_INSTANCE} --cpuInstanceType ${CPU_INSTANCE} --gpuInstanceType ${GPU_INSTANCE} --mode ${PRIMEHUB_MODE} --keycloak-password ${PASSWORD} --primehub-password ${PASSWORD} || exit 1
 
 echo "Completed"
 exit 0

--- a/extras/primehub-ce-starter-cloudformation.yaml
+++ b/extras/primehub-ce-starter-cloudformation.yaml
@@ -27,6 +27,8 @@ Resources:
               export AWS_STACK_NAME="${AWS::StackName}"
               export AWS_REGION="${AWS::Region}"
               export GIT_TAG='cfTemplate'
+              export CPU_INSTANCE="${CPUInstanceType}"
+              export GPU_INSTANCE="${GPUInstanceType}"
 
               ./run-cdk.sh
               /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --region ${AWS::Region} --resource PrimeHubCDKBootstrapEC2
@@ -137,4 +139,23 @@ Parameters:
     AllowedValues:
       - ce
     Description: PrimeHub Community Edition Mode
-
+  CPUInstanceType:
+    Type: String
+    Default: t3.xlarge
+    AllowedValues:
+      - t3.xlarge
+      - t3.2xlarge
+      - t3a.xlarge
+      - t3a.2xlarge
+      - m5.xlarge
+      - m5.2xlarge
+      - c5.xlarge
+      - c5.2xlarge
+    Description: The Instance Type of auto scaling CPU node group
+  GPUInstanceType:
+    Type: String
+    Default: g4dn.xlarge
+    AllowedValues:
+      - g4dn.xlarge
+      - g4dn.2xlarge
+    Description: The Instance Type of auto scaling GPU node group

--- a/extras/primehub-starter-cloudformation.yaml
+++ b/extras/primehub-starter-cloudformation.yaml
@@ -27,6 +27,8 @@ Resources:
               export AWS_STACK_NAME="${AWS::StackName}"
               export AWS_REGION="${AWS::Region}"
               export GIT_TAG='cfTemplate'
+              export CPU_INSTANCE="${CPUInstanceType}"
+              export GPU_INSTANCE="${GPUInstanceType}"
 
               ./run-cdk.sh
               /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --region ${AWS::Region} --resource PrimeHubCDKBootstrapEC2
@@ -137,4 +139,23 @@ Parameters:
     AllowedValues:
       - ee
     Description: PrimeHub Enterprise Edition Mode
-
+  CPUInstanceType:
+    Type: String
+    Default: t3.xlarge
+    AllowedValues:
+      - t3.xlarge
+      - t3.2xlarge
+      - t3a.xlarge
+      - t3a.2xlarge
+      - m5.xlarge
+      - m5.2xlarge
+      - c5.xlarge
+      - c5.2xlarge
+    Description: The Instance Type of auto scaling CPU node group
+  GPUInstanceType:
+    Type: String
+    Default: g4dn.xlarge
+    AllowedValues:
+      - g4dn.xlarge
+      - g4dn.2xlarge
+    Description: The Instance Type of auto scaling GPU node group

--- a/lib/eks-cluster-Stack.ts
+++ b/lib/eks-cluster-Stack.ts
@@ -27,6 +27,7 @@ export interface EksStackProps extends cdk.StackProps {
   availabilityZone: string;
   cpuInstance: string;
   gpuInstance: string;
+  systemInstance: string;
   masterRole?:  string;
   k8sInfraOnly?: string;
 }
@@ -76,12 +77,13 @@ export class EKSCluster extends cdk.Stack {
       minSize: 1,
       maxSize: 3,
       diskSize: 60,
-      instanceTypes: [new InstanceType(`${props.cpuInstance}.xlarge`)],
+      instanceTypes: [new InstanceType(props.systemInstance)],
       subnets: {subnetType: ec2.SubnetType.PUBLIC, availabilityZones: [props.availabilityZone]},
       tags: {
         Name: `${clusterName}-default-node-group`,
         cluster: clusterName,
         owner: props.username,
+        InstanceType: props.systemInstance,
         clusterType: "dev-eks"
       },
     });
@@ -91,7 +93,7 @@ export class EKSCluster extends cdk.Stack {
       desiredCapacity: 0,
       minCapacity: 0,
       maxCapacity: 2,
-      instanceType: new InstanceType(`${props.cpuInstance}.xlarge`),
+      instanceType: new InstanceType(props.cpuInstance),
       blockDevices: [{deviceName: '/dev/xvda', volume: BlockDeviceVolume.ebs(80)}],
       vpcSubnets: {subnetType: ec2.SubnetType.PUBLIC, availabilityZones: [props.availabilityZone]},
       bootstrapOptions: {
@@ -101,6 +103,7 @@ export class EKSCluster extends cdk.Stack {
     cdk.Tags.of(cpuASG).add('Name', `${clusterName}-scaled-cpu-pool`);
     cdk.Tags.of(cpuASG).add('cluster', clusterName);
     cdk.Tags.of(cpuASG).add('owner', props.username);
+    cdk.Tags.of(cpuASG).add('instanceType', props.cpuInstance);
     cdk.Tags.of(cpuASG).add('clusterType', 'dev-eks');
     cdk.Tags.of(cpuASG).add(`k8s.io/cluster-autoscaler/${clusterName}`, 'owned');
     cdk.Tags.of(cpuASG).add('k8s.io/cluster-autoscaler/enabled', 'TRUE');
@@ -114,7 +117,7 @@ export class EKSCluster extends cdk.Stack {
       desiredCapacity: 0,
       minCapacity: 0,
       maxCapacity: 2,
-      instanceType: new InstanceType(`${props.gpuInstance}.xlarge`),
+      instanceType: new InstanceType(props.gpuInstance),
       blockDevices: [{deviceName: '/dev/xvda', volume: BlockDeviceVolume.ebs(80)}],
       vpcSubnets: {subnetType: ec2.SubnetType.PUBLIC, availabilityZones: [props.availabilityZone]},
       bootstrapOptions: {
@@ -125,6 +128,7 @@ export class EKSCluster extends cdk.Stack {
     cdk.Tags.of(gpuASG).add('Name', `${clusterName}-scaled-gpu-pool`);
     cdk.Tags.of(gpuASG).add('cluster', clusterName);
     cdk.Tags.of(gpuASG).add('owner', props.username);
+    cdk.Tags.of(gpuASG).add('instanceType', props.gpuInstance);
     cdk.Tags.of(gpuASG).add('clusterType', 'dev-eks');
     cdk.Tags.of(gpuASG).add(`k8s.io/cluster-autoscaler/${clusterName}`, 'owned');
     cdk.Tags.of(gpuASG).add('k8s.io/cluster-autoscaler/enabled', 'TRUE');


### PR DESCRIPTION
- User can select CPU/GPU instance type when open Launch Stack URL
- Change the input of instance type options from family name to instance type name. ex `t3a` -> `t3a.xlarge`

Signed-off-by: Kent Huang <kentwelcome@gmail.com>