### PR TITLE
[Feature] ch20265 cpu/gpu desired capacity can be config by options

### DIFF
--- a/bin/index.ts
+++ b/bin/index.ts
@@ -22,10 +22,12 @@ const systemInstance = app.node.tryGetContext('systemInstance') || 't3a.xlarge';
 const k8sInfraOnly = app.node.tryGetContext('k8sInfraOnly') || 'false';
 const cpuDesiredCapacity = parseInt(app.node.tryGetContext('cpuDesiredCapacity') || '0', 10) ;
 const gpuDesiredCapacity = parseInt(app.node.tryGetContext('gpuDesiredCapacity') || '0', 10) ;
+const cpuMaxCapacity = parseInt(app.node.tryGetContext('cpuMaxCapacity') || '2', 10) ;
+const gpuMaxCapacity = parseInt(app.node.tryGetContext('gpuMaxCapacity') || '2', 10) ;
 
-const eksSackName = `eks-${name}-cdk-stack`;
 
-const eksClusterStack = new EKSCluster(app, eksSackName , {
+const eksStackName = `eks-${name}-cdk-stack`;
+const eksClusterStack = new EKSCluster(app, eksStackName , {
   env: env,
   name: name,
   username: username,
@@ -39,12 +41,14 @@ const eksClusterStack = new EKSCluster(app, eksSackName , {
   systemInstance: systemInstance,
   cpuDesiredCapacity: cpuDesiredCapacity,
   gpuDesiredCapacity: gpuDesiredCapacity,
+  cpuMaxCapacity: cpuMaxCapacity,
+  gpuMaxCapacity: gpuMaxCapacity,
   k8sInfraOnly: k8sInfraOnly,
   primehubVersion: primehubVersion,
 });
 
 eksClusterStack.templateOptions.description = `Setup AWS EKS environment with PrimeHub by AWS CDK.
-The PrimeHub access information will show in the 'Outputs' tab once the stack status of '${eksSackName}' becomes CREATE_COMPLETE.
+The PrimeHub access information will show in the 'Outputs' tab once the stack status of '${eksStackName}' becomes CREATE_COMPLETE.
 For more information, please visit: https://github.com/InfuseAI/primehub-aws-cdk`;
 
 cdk.Tags.of(eksClusterStack).add("owner", username);

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -20,8 +20,12 @@ const cpuInstance = app.node.tryGetContext('cpuInstance') || 't3a.xlarge';
 const gpuInstance = app.node.tryGetContext('gpuInstance') || 'g4dn.xlarge';
 const systemInstance = app.node.tryGetContext('systemInstance') || 't3a.xlarge';
 const k8sInfraOnly = app.node.tryGetContext('k8sInfraOnly') || 'false';
+const cpuDesiredCapacity = parseInt(app.node.tryGetContext('cpuDesiredCapacity') || '0', 10) ;
+const gpuDesiredCapacity = parseInt(app.node.tryGetContext('gpuDesiredCapacity') || '0', 10) ;
 
-const eksClusterStack = new EKSCluster(app, `eks-${name}-cdk-stack`, {
+const eksSackName = `eks-${name}-cdk-stack`;
+
+const eksClusterStack = new EKSCluster(app, eksSackName , {
   env: env,
   name: name,
   username: username,
@@ -33,11 +37,14 @@ const eksClusterStack = new EKSCluster(app, `eks-${name}-cdk-stack`, {
   cpuInstance: cpuInstance,
   gpuInstance: gpuInstance,
   systemInstance: systemInstance,
+  cpuDesiredCapacity: cpuDesiredCapacity,
+  gpuDesiredCapacity: gpuDesiredCapacity,
   k8sInfraOnly: k8sInfraOnly,
   primehubVersion: primehubVersion,
 });
 
 eksClusterStack.templateOptions.description = `Setup AWS EKS environment with PrimeHub by AWS CDK.
+The PrimeHub access information will show in the 'Outputs' tab once the stack status of '${eksSackName}' becomes CREATE_COMPLETE.
 For more information, please visit: https://github.com/InfuseAI/primehub-aws-cdk`;
 
 cdk.Tags.of(eksClusterStack).add("owner", username);

--- a/deploy
+++ b/deploy
@@ -13,6 +13,8 @@ CPU_INSTANCE='t3a.xlarge'
 GPU_INSTANCE='g4dn.xlarge'
 CPU_DESIRED_SIZE=0
 GPU_DESIRED_SIZE=0
+CPU_MAX_SIZE=2
+GPU_MAX_SIZE=2
 SYS_INSTANCE='t3a.xlarge'
 PH_PASSWORD=''
 KC_PASSWORD=''
@@ -35,18 +37,20 @@ usage() {
 Usage: $SELF [options] <ClusterName>
 
 Options:
-  --mode                  <mode>              : Set the PrimeHub mode ( Default: ${PRIMEHUB_MODE}, Support: ee, ce, deploy )
-  --region                <aws region>        : Set the AWS region ( Default: ${AWS_REGION} )
-  --zone                  <zone>              : Set the AWS availability zones ( Default: ${AWS_ZONE} )
+  --mode                  <mode>              : Set the PrimeHub mode           ( Default: ${PRIMEHUB_MODE}, Support: ee, ce, deploy )
+  --region                <aws region>        : Set the AWS region              ( Default: ${AWS_REGION} )
+  --zone                  <zone>              : Set the AWS availability zones  ( Default: ${AWS_ZONE} )
   --dry-run                                   : Dry run AWS CDK deploy
   --k8s-infra                                 : Only setup AWS ESK without installing PrimeHub
   --domain                <base domain>       : Provide the base domain managed by AWS Route 53
   --primehub-version      <version>           : Set the specific version number of PrimeHub
-  --cpu-instance-type     <ec2 instance type> : Set the EKS default CPU node group instance type ( Default: ${CPU_INSTANCE} )
-  --gpu-instance-type     <ec2 instance type> : Set the EKS default GPU node group instance type ( Default: ${GPU_INSTANCE} )
+  --system-instance-type  <ec2 instance type> : Set the EKS default system node group instance type ( Default: ${SYS_INSTANCE} )
+  --cpu-instance-type     <ec2 instance type> : Set the EKS default CPU node group instance type    ( Default: ${CPU_INSTANCE} )
+  --gpu-instance-type     <ec2 instance type> : Set the EKS default GPU node group instance type    ( Default: ${GPU_INSTANCE} )
   --cpu-desired-capacity  <number>            : Set the EKS default CPU node group desired capacity ( Default: 0 )
   --gpu-desired-capactiy  <number>            : Set the EKS default GPU node group desired capacity ( Default: 0 )
-  --system-instance-type  <ec2 instance type> : Set the EKS default system node group instance type ( Default: ${SYS_INSTANCE} )
+  --cpu-max-capacity      <number>            : Set the EKS default CPU node group max capacity     ( Default: 2 )
+  --gpu-max-capactiy      <number>            : Set the EKS default GPU node group max capacity     ( Default: 2 )
   --keycloak-password     <password>          : Set the password of Keycloak admin account
   --primehub-password     <password>          : Set the password of PrimeHub default account
   -h, --help                                  : Show this message
@@ -98,6 +102,8 @@ cdk::context() {
       -c gpuInstance=$GPU_INSTANCE \
       -c cpuDesiredCapacity=$CPU_DESIRED_SIZE \
       -c gpuDesiredCapacity=$GPU_DESIRED_SIZE \
+      -c cpuMaxCapacity=$CPU_MAX_SIZE \
+      -c gpuMaxCapacity=$GPU_MAX_SIZE \
       -c systemInstance=$SYS_INSTANCE \
       -c basedDomain=$AWS_BASED_DOMAIN \
       -c primehubMode=$PRIMEHUB_MODE \
@@ -172,6 +178,14 @@ args::parse() {
       --gpu-desired-capacity)
         shift
         GPU_DESIRED_SIZE=${1}
+      ;;
+      --cpu-max-capacity)
+        shift
+        CPU_MAX_SIZE=${1}
+      ;;
+      --gpu-max-capacity)
+        shift
+        GPU_MAX_SIZE=${1}
       ;;
       --dry-run)
         DRY_MODE=true

--- a/deploy
+++ b/deploy
@@ -11,6 +11,8 @@ AWS_REGION=${AWS_REGION:-$(aws configure get region || echo 'ap-northeast-1')}
 AWS_ZONE=${AWS_ZONE:-a}
 CPU_INSTANCE='t3a.xlarge'
 GPU_INSTANCE='g4dn.xlarge'
+CPU_DESIRED_SIZE=0
+GPU_DESIRED_SIZE=0
 SYS_INSTANCE='t3a.xlarge'
 PH_PASSWORD=''
 KC_PASSWORD=''
@@ -42,6 +44,8 @@ Options:
   --primehub-version      <version>           : Set the specific version number of PrimeHub
   --cpu-instance-type     <ec2 instance type> : Set the EKS default CPU node group instance type ( Default: ${CPU_INSTANCE} )
   --gpu-instance-type     <ec2 instance type> : Set the EKS default GPU node group instance type ( Default: ${GPU_INSTANCE} )
+  --cpu-desired-capacity  <number>            : Set the EKS default CPU node group desired capacity ( Default: 0 )
+  --gpu-desired-capactiy  <number>            : Set the EKS default GPU node group desired capacity ( Default: 0 )
   --system-instance-type  <ec2 instance type> : Set the EKS default system node group instance type ( Default: ${SYS_INSTANCE} )
   --keycloak-password     <password>          : Set the password of Keycloak admin account
   --primehub-password     <password>          : Set the password of PrimeHub default account
@@ -92,6 +96,8 @@ cdk::context() {
       -c primehubVersion=$PRIMEHUB_VERSION \
       -c cpuInstance=$CPU_INSTANCE \
       -c gpuInstance=$GPU_INSTANCE \
+      -c cpuDesiredCapacity=$CPU_DESIRED_SIZE \
+      -c gpuDesiredCapacity=$GPU_DESIRED_SIZE \
       -c systemInstance=$SYS_INSTANCE \
       -c basedDomain=$AWS_BASED_DOMAIN \
       -c primehubMode=$PRIMEHUB_MODE \
@@ -158,6 +164,14 @@ args::parse() {
       --system-instance-type)
         shift
         SYS_INSTANCE=${1}
+      ;;
+      --cpu-desired-capacity)
+        shift
+        CPU_DESIRED_SIZE=${1}
+      ;;
+      --gpu-desired-capacity)
+        shift
+        GPU_DESIRED_SIZE=${1}
       ;;
       --dry-run)
         DRY_MODE=true

--- a/extras/ec2-user-script.sh
+++ b/extras/ec2-user-script.sh
@@ -52,6 +52,7 @@ export AWS_REGION
   --system-instance-type ${SYS_INSTANCE} \
   --cpu-instance-type ${CPU_INSTANCE} \
   --gpu-instance-type ${GPU_INSTANCE} \
+  --cpu-desired-capacity 1 \
   --mode ${PRIMEHUB_MODE} \
   --keycloak-password ${PASSWORD} \
   --primehub-password ${PASSWORD} || exit 1

--- a/lib/eks-cluster-Stack.ts
+++ b/lib/eks-cluster-Stack.ts
@@ -31,6 +31,8 @@ export interface EksStackProps extends cdk.StackProps {
   systemInstance: string;
   cpuDesiredCapacity: number;
   gpuDesiredCapacity: number;
+  cpuMaxCapacity: number;
+  gpuMaxCapacity: number;
   masterRole?:  string;
   k8sInfraOnly?: string;
   primehubVersion?: string;
@@ -97,7 +99,7 @@ export class EKSCluster extends cdk.Stack {
       autoScalingGroupName: `${clusterName}-scaled-cpu-pool`,
       desiredCapacity: props.cpuDesiredCapacity,
       minCapacity: 0,
-      maxCapacity: 2,
+      maxCapacity: props.cpuMaxCapacity,
       instanceType: new InstanceType(props.cpuInstance),
       blockDevices: [{deviceName: '/dev/xvda', volume: BlockDeviceVolume.ebs(80)}],
       vpcSubnets: {subnetType: ec2.SubnetType.PUBLIC, availabilityZones: [props.availabilityZone]},
@@ -121,7 +123,7 @@ export class EKSCluster extends cdk.Stack {
       autoScalingGroupName: `${clusterName}-scaled-gpu-pool`,
       desiredCapacity: props.gpuDesiredCapacity,
       minCapacity: 0,
-      maxCapacity: 2,
+      maxCapacity: props.gpuMaxCapacity,
       instanceType: new InstanceType(props.gpuInstance),
       blockDevices: [{deviceName: '/dev/xvda', volume: BlockDeviceVolume.ebs(80)}],
       vpcSubnets: {subnetType: ec2.SubnetType.PUBLIC, availabilityZones: [props.availabilityZone]},

--- a/lib/eks-cluster-Stack.ts
+++ b/lib/eks-cluster-Stack.ts
@@ -29,6 +29,8 @@ export interface EksStackProps extends cdk.StackProps {
   cpuInstance: string;
   gpuInstance: string;
   systemInstance: string;
+  cpuDesiredCapacity: number;
+  gpuDesiredCapacity: number;
   masterRole?:  string;
   k8sInfraOnly?: string;
   primehubVersion?: string;
@@ -93,7 +95,7 @@ export class EKSCluster extends cdk.Stack {
 
     const cpuASG = eksCluster.addAutoScalingGroupCapacity('OnDemandCpuASG', {
       autoScalingGroupName: `${clusterName}-scaled-cpu-pool`,
-      desiredCapacity: 0,
+      desiredCapacity: props.cpuDesiredCapacity,
       minCapacity: 0,
       maxCapacity: 2,
       instanceType: new InstanceType(props.cpuInstance),
@@ -117,7 +119,7 @@ export class EKSCluster extends cdk.Stack {
 
     const gpuASG = eksCluster.addAutoScalingGroupCapacity('OnDemandGpuASG', {
       autoScalingGroupName: `${clusterName}-scaled-gpu-pool`,
-      desiredCapacity: 0,
+      desiredCapacity: props.gpuDesiredCapacity,
       minCapacity: 0,
       maxCapacity: 2,
       instanceType: new InstanceType(props.gpuInstance),

--- a/lib/primehub.ts
+++ b/lib/primehub.ts
@@ -147,7 +147,7 @@ export class PrimeHub extends cdk.Construct {
               namespace: 'hub',
               release: 'primehub',
               values: helmValues,
-              version: props.primehubVersion,
+              version: props.primehubVersion || '',
               timeout: cdk.Duration.minutes(15),
               wait: false,
           });


### PR DESCRIPTION
 - fix deploy primehub without giving primehub version issue
 - update description of eks cdk stack to show how to access primehub
 - default set cpu desired capacity as 1 when run the one click aws

Signed-off-by: Kent Huang <kentwelcome@gmail.com>