### PR TITLE
[1-click] invalid parameter: redirect_uri in notebook panel

### DIFF
--- a/lib/nginx-ingress.ts
+++ b/lib/nginx-ingress.ts
@@ -44,7 +44,6 @@ export class IngressNginxController extends cdk.Construct {
                     enabled: false,
                 },
                 config: {
-                    'ssl-redirect': 'false',
                     'use-forwarded-headers': 'true',
                 },
                 containerPort: {

--- a/lib/nginx-ingress.ts
+++ b/lib/nginx-ingress.ts
@@ -44,6 +44,7 @@ export class IngressNginxController extends cdk.Construct {
                     enabled: false,
                 },
                 config: {
+                    'ssl-redirect': 'false',
                     'use-forwarded-headers': 'true',
                 },
                 containerPort: {

--- a/lib/primehub.ts
+++ b/lib/primehub.ts
@@ -116,7 +116,31 @@ export class PrimeHub extends cdk.Construct {
                         pvc: {
                             storageClassName: 'gp2'
                         }
-                    }
+                    },
+                    extraEnv: [
+                      {
+                        name: 'KC_CLIENT_SECRET',
+                        valueFrom: {
+                          secretKeyRef: {
+                            name: 'primehub-client-jupyterhub',
+                            key: 'client_secret'
+                          }
+                        }
+                      },
+                      {
+                        name: 'GRAPHQL_SHARED_SECRET',
+                        valueFrom: {
+                          secretKeyRef: {
+                            name: 'primehub-graphql-shared-secret',
+                            key: 'sharedSecret'
+                          }
+                        }
+                      },
+                      {
+                        name: 'OAUTH_CALLBACK_URL',
+                        value: `https://${props.primehubDomain}/hub/oauth_callback`
+                      }
+                    ],
                 },
                 proxy: {
                     secretToken: hubProxySecretKey,


### PR DESCRIPTION
Fix oauth callback url